### PR TITLE
Allow for interruption and cleanup at all await points during auth flow

### DIFF
--- a/client/components/IntroModule/IntroModule.tsx
+++ b/client/components/IntroModule/IntroModule.tsx
@@ -1,5 +1,4 @@
-import React, { Suspense } from "react";
-import { NoSSR } from "../../pages/_app";
+import React from "react";
 import { Box } from "../Box";
 import { HeaderLarge, Paragraph, SpanText } from "../Text/Text";
 import UserForm from "./UserForm";
@@ -17,9 +16,7 @@ const IntroModule = () => {
         <Box>
           <Paragraph bold>Talk to fellow jpeg holders</Paragraph>
         </Box>
-        <NoSSR>
-          <Suspense fallback={<Box style={{ height: 56 }} />}>{<UserForm />}</Suspense>
-        </NoSSR>
+        <UserForm />
       </Box>
     </>
   );

--- a/client/components/IntroModule/UserForm.tsx
+++ b/client/components/IntroModule/UserForm.tsx
@@ -1,8 +1,8 @@
 import { useState, useCallback, ChangeEvent, useEffect } from "react";
+import { AuthenticatingStatus } from "../../../protocol/auth";
 import { useWeb3Context, WalletStatus } from "../../hooks/use_web3";
-import { AuthenticatingStatus, useWeb3Auth } from "../../hooks/use_web3_auth";
+import { useWeb3Auth } from "../../hooks/use_web3_auth";
 import { useStore } from "../../store/store";
-import { logger } from "../../utils/logger";
 import { Box } from "../Box";
 import { Button } from "../Button";
 import { ArrowIcon } from "../Icons";
@@ -11,24 +11,77 @@ import { Spinner } from "../Spinner/Spinner";
 import { Stack } from "../Stack";
 import { Paragraph, SpanText } from "../Text/Text";
 
-export const UserForm = () => {
-  const { providerInstalled, walletStatus, requestAccounts } = useWeb3Context();
+const AuthStatus = ({
+  authData,
+  authenticatingStatus,
+  screenName,
+}: {
+  authData: {
+    nonce: string;
+    sessionId: string;
+  } | null;
+  authenticatingStatus: AuthenticatingStatus;
+  screenName?: string;
+}) => {
+  const { walletStatus, requestAccounts } = useWeb3Context();
+  const onConnectClick = useCallback(() => requestAccounts(), [requestAccounts]);
 
+  if (walletStatus === WalletStatus.Unknown || walletStatus === WalletStatus.Error) {
+    return (
+      <>
+        <Stack itemSpace="xs" shrink>
+          <Button icon={<ArrowIcon />} border={false} onClick={onConnectClick}>
+            Connect Wallet
+          </Button>
+        </Stack>
+      </>
+    );
+  } else if (walletStatus === WalletStatus.RequestUnlocked) {
+    return <>Connecting wallet</>;
+  } else if (walletStatus === WalletStatus.StillRequestUnlocked) {
+    return <>Connecting wallet - please unlock your wallet provider</>;
+  } else if (
+    walletStatus === WalletStatus.Unlocked &&
+    authData === null &&
+    authenticatingStatus === AuthenticatingStatus.Authenticated
+  ) {
+    return (
+      <>
+        Fetching wallet data <Spinner mode="connecting" />
+      </>
+    );
+  } else {
+    switch (authenticatingStatus) {
+      case AuthenticatingStatus.SigningMessage: {
+        return (
+          <>
+            Signing in as {screenName} <Spinner mode="connecting" />
+          </>
+        );
+      }
+      default:
+        return (
+          <>
+            Fetching wallet data <Spinner mode="connecting" />
+          </>
+        );
+    }
+  }
+};
+
+export const UserForm = () => {
+  const { providerInstalled, walletStatus } = useWeb3Context();
   const { authenticatingStatus, handleLoginClick } = useWeb3Auth();
   const { authData } = useStore();
 
   const [error, setError] = useState(false);
-  const { screenName, setScreenName } = useStore();
+  const [screenName, setScreenName] = useState<string>();
 
-  const onChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      setScreenName(e.target.value);
-    },
-    [setScreenName],
-  );
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
+    setScreenName(e.target.value);
+  }, []);
 
   const onLoginClick = useCallback(() => screenName && handleLoginClick(screenName), [handleLoginClick, screenName]);
-  const onConnectClick = useCallback(() => requestAccounts(), [requestAccounts]);
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -45,47 +98,6 @@ export const UserForm = () => {
     }
   }, [error, screenName?.length]);
 
-  const AuthStatus = useCallback(() => {
-    if (walletStatus === WalletStatus.Unknown || walletStatus === WalletStatus.Error) {
-      return (
-        <>
-          <Stack itemSpace="xs" shrink>
-            <Button icon={<ArrowIcon />} border={false} onClick={onConnectClick}>
-              Connect Wallet
-            </Button>
-          </Stack>
-        </>
-      );
-    } else if (walletStatus === WalletStatus.RequestUnlocked) {
-      return <>Connecting wallet</>;
-    } else if (walletStatus === WalletStatus.StillRequestUnlocked) {
-      return <>Connecting wallet - please unlock your wallet provider</>;
-    } else if (
-      walletStatus === WalletStatus.Unlocked &&
-      authData === null &&
-      authenticatingStatus === AuthenticatingStatus.Authenticated
-    ) {
-      return (
-        <>
-          Fetching wallet data <Spinner mode="connecting" />
-        </>
-      );
-    } else {
-      logger.info(`AuthStatus changed ${JSON.stringify(authenticatingStatus)}`);
-      switch (authenticatingStatus) {
-        case AuthenticatingStatus.SigningMessage: {
-          return (
-            <>
-              Signing in as {screenName} <Spinner mode="connecting" />
-            </>
-          );
-        }
-        default:
-          return <></>;
-      }
-    }
-  }, [authData, authenticatingStatus, onConnectClick, screenName, walletStatus]);
-
   return (
     <>
       {!providerInstalled ? (
@@ -97,7 +109,7 @@ export const UserForm = () => {
           {authData !== null &&
           walletStatus === WalletStatus.Unlocked &&
           authenticatingStatus === AuthenticatingStatus.Unauthenticated ? (
-            <>
+            <Stack row itemSpace="xs" shrink padding>
               <InputField
                 value={screenName ?? ""}
                 onChange={onChange}
@@ -108,11 +120,11 @@ export const UserForm = () => {
                 borderColor={error ? "NeonPurple" : "GrapePurple"}
               />
               <Button icon={<ArrowIcon />} border={false} onClick={onLoginClick}></Button>
-            </>
+            </Stack>
           ) : (
             <Box padding="xs">
               <Paragraph textColor="NeonPurple">
-                <AuthStatus />
+                <AuthStatus authData={authData} authenticatingStatus={authenticatingStatus} screenName={screenName} />
               </Paragraph>
             </Box>
           )}

--- a/client/hooks/use_web3.tsx
+++ b/client/hooks/use_web3.tsx
@@ -24,7 +24,7 @@ export type RequestAccounts = ReturnType<typeof useWeb3>["requestAccounts"];
 export type UseWeb3 = ReturnType<typeof useWeb3>;
 
 const useWeb3 = () => {
-  const [accounts, setAccounts] = useState<string[]>();
+  const [accounts, setAccounts] = useState<string[]>([]);
   const [chainId, setChainId] = useState<string>();
   const messageId = useRef(0);
   const requestingAccounts = useRef(false);
@@ -76,8 +76,14 @@ const useWeb3 = () => {
       const onAccountsChanged = (accounts: Array<string>) => {
         if (!shutdown) {
           // If the wallet is unlocked, get the accounts
-          logger.info(`onAccountsChanged:\n${accounts.join("\n")}`);
-          setAccounts(accounts);
+          logger.info(`onAccountsChanged: ${accounts.join(":")} accounts.length ${accounts.length}`);
+          setAccounts(oldAccounts =>
+            oldAccounts &&
+            oldAccounts.length === accounts.length &&
+            oldAccounts.every(oldAccount => accounts.some(account => account === oldAccount))
+              ? oldAccounts
+              : accounts,
+          );
           if (accounts.length > 0) {
             setWalletStatus(WalletStatus.Unlocked);
           } else {
@@ -100,7 +106,13 @@ const useWeb3 = () => {
         const [accounts, chainId] = await Promise.all([getAccounts(), getChainId()]);
         if (!shutdown) {
           setChainId(chainId);
-          setAccounts(accounts);
+          setAccounts(oldAccounts =>
+            oldAccounts &&
+            oldAccounts.length === accounts.length &&
+            oldAccounts.every(oldAccount => accounts.some(account => account === oldAccount))
+              ? oldAccounts
+              : accounts,
+          );
           if (accounts.length > 0) {
             setWalletStatus(WalletStatus.Unlocked);
           } else {
@@ -139,7 +151,13 @@ const useWeb3 = () => {
         const chainId: string = await getChainId();
         logger.info(`requestAccounts ${JSON.stringify({ accounts, chainId })}`);
         setChainId(chainId);
-        setAccounts(accounts);
+        setAccounts(oldAccounts =>
+          oldAccounts &&
+          oldAccounts.length === accounts.length &&
+          oldAccounts.every(oldAccount => accounts.some(account => account === oldAccount))
+            ? oldAccounts
+            : accounts,
+        );
         if (accounts.length > 0) {
           setWalletStatus(WalletStatus.Unlocked);
         } else {

--- a/client/store/store.ts
+++ b/client/store/store.ts
@@ -1,8 +1,7 @@
 import createStore from "zustand";
 import { configurePersist } from "zustand-persist";
-import { AuthRequestWalletData } from "../../protocol/auth";
+import { AuthRequestWalletData, AuthenticatingStatus } from "../../protocol/auth";
 import { ERC20Result, NFTResult } from "../../protocol/tokens";
-import { AuthenticatingStatus } from "../hooks/use_web3_auth";
 
 const noopStore = {
   setItem: (key: string, value: string) => undefined,

--- a/client/utils/authRequest.ts
+++ b/client/utils/authRequest.ts
@@ -23,7 +23,7 @@ function getIceServersUrl() {
   }
 }
 
-export async function getIceServers(): Promise<RTCIceServer[] | undefined> {
+export async function getIceServers(signal: AbortSignal): Promise<RTCIceServer[] | undefined> {
   try {
     const response = await fetch(getIceServersUrl(), {
       method: "GET",
@@ -35,6 +35,7 @@ export async function getIceServers(): Promise<RTCIceServer[] | undefined> {
       },
       redirect: "follow",
       referrerPolicy: "no-referrer",
+      signal,
     });
 
     logger.info(`getIceServers`, response);
@@ -46,7 +47,7 @@ export async function getIceServers(): Promise<RTCIceServer[] | undefined> {
     logger.error(`getIceServers error`, err);
   }
 }
-export async function postAuthRequest(request: AuthRequest): Promise<number | void> {
+export async function postAuthRequest(request: AuthRequest, signal: AbortSignal): Promise<number | void> {
   try {
     const response = await fetch(getAuthUrl(), {
       method: "POST",
@@ -59,6 +60,7 @@ export async function postAuthRequest(request: AuthRequest): Promise<number | vo
       redirect: "follow",
       referrerPolicy: "no-referrer",
       body: JSON.stringify(request),
+      signal,
     });
     return response.status;
   } catch (err) {
@@ -70,6 +72,7 @@ export async function getAuthRequestWalletData(
   chainId: string,
   walletAddress: string,
   nonce: string,
+  signal: AbortSignal,
 ): Promise<AuthRequestWalletData | void> {
   try {
     const response = await fetch(getAuthUrl() + `?chainId=${chainId}&walletAddress=${walletAddress}&nonce=${nonce}`, {
@@ -79,16 +82,19 @@ export async function getAuthRequestWalletData(
       credentials: "include",
       redirect: "follow",
       referrerPolicy: "no-referrer",
+      signal,
     });
     const data: AuthRequestWalletData = await response.json();
     logger.info(`getAuthRequestWalletData JSON `, data);
     return data;
   } catch (err) {
-    logger.error(`getAuthRequestWalletData error`, err);
+    if (!signal.aborted) {
+      logger.error(`getAuthRequestWalletData error`, err);
+    }
   }
 }
 
-export async function deleteAuth(): Promise<number | void> {
+export async function deleteAuth(signal: AbortSignal): Promise<number | void> {
   try {
     const response = await fetch(getAuthUrl(), {
       method: "DELETE",
@@ -97,11 +103,14 @@ export async function deleteAuth(): Promise<number | void> {
       credentials: "include",
       redirect: "follow",
       referrerPolicy: "no-referrer",
+      signal,
     });
     const status = response.status;
     logger.info(`deleteAuth `, status);
     return status;
   } catch (err) {
-    logger.error(`deleteAuth error`, err);
+    if (!signal.aborted) {
+      logger.error(`deleteAuth error`, err);
+    }
   }
 }

--- a/protocol/auth.ts
+++ b/protocol/auth.ts
@@ -30,4 +30,10 @@ export interface AuthRequestData {
   screenName: string;
 }
 
+export enum AuthenticatingStatus {
+  Unauthenticated = "Unauthenticated",
+  SigningMessage = "SigningMessage",
+  Authenticated = "Authenticated",
+}
+
 export const authCookieName = "chatWalletteAuth";


### PR DESCRIPTION
Add support for cancelation and appropriate cleanup/rollback at each step of the auth flow.
Conver the login timeout to use this new interruptibility.
Remove no longer needed Suspense from the auth components. (Leftover from when we loaded Web3.js).
Move AuthenticatingStatus enum out of the hook to silence HMR issues of the AuthenticatingStatus not being initialized prior to being referenced by store when changing the hook.
