### PR TITLE
Create a list of tokens to be excluded from matching

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -238,6 +238,7 @@ const start = async () => {
 
   const walletConnectionStore = await getConnectionStore();
   const signalingServer = new WebRTCSignalingServer(walletConnectionStore);
+  await signalingServer.applyConfigurations();
 
   const [moralisApiKey, subspaceApiKey, gcpMetadata] = await Promise.all([
     getMoralisApiKey(),

--- a/server/src/web_rtc_signaling_server.ts
+++ b/server/src/web_rtc_signaling_server.ts
@@ -30,6 +30,13 @@ export class WebRTCSignalingServer {
     });
   }
 
+  public async applyConfigurations(): Promise<void> {
+    // Exclude these tokens for matching.
+    await this.connectionStore.updateExcludedTokens([
+      "0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85", // ENS token
+    ]);
+  }
+
   public async handleRequest(
     log: FastifyLoggerInstance,
     walletAddress: string,


### PR DESCRIPTION
Right now, the exclude list only has ENS. We can add more as needed. 

When updating a wallet, the excluded tokens are subtracted from the wallet's token list, and then stored for future matching.