### PR TITLE
Print process.env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV ANALYTICS_ID=$_ANALYTICS_ID
 ENV REDISHOST=$REDISHOST_ARG
 ENV REDISPORT=$REDISPORT_ARG
 
-RUN echo environment variable ANALYTICS_ID=${ANALYTICS_ID}
+RUN echo environment variable ANALYTICS_ID=$ANALYTICS_ID , build-arg _ANALYTICS_ID=$_ANALYTICS_ID
 
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001

--- a/server/src/analytics.ts
+++ b/server/src/analytics.ts
@@ -29,6 +29,7 @@ export async function sendAnalytics(log: FastifyLoggerInstance, event: Analytics
     log.info(
       `const ANALYTICS_ID=${ANALYTICS_ID}, environment variable process.env.ANALYTICS_ID=${process.env.ANALYTICS_ID}`,
     );
+    log.info(`environment variables ${JSON.stringify(process.env)}}`);
     if (ANALYTICS_ID) {
       const params = new URLSearchParams();
       // Required.


### PR DESCRIPTION
Getting close. I can see build.yaml passing substituted values into docker build. 

now the problem is that when the sendAnalytics function runs, process.env.ANALYTICS_ID is empty.

Print the entire process.env to see what's being set.