### PR TITLE
Add query option to force private relay mode and use default ice candidate pool

### DIFF
--- a/client/hooks/use_chat_session.ts
+++ b/client/hooks/use_chat_session.ts
@@ -141,7 +141,14 @@ export const useChatSession = ({
       const chatId = sessionChatId;
 
       const peerConnectionId = peerConnectionCounter++;
-      const newConnection = new RTCPeerConnection({ iceCandidatePoolSize: 1, iceServers });
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const privacyEnabled = urlParams.get("privacy") !== null;
+
+      const newConnection = new RTCPeerConnection({
+        iceServers,
+        iceTransportPolicy: privacyEnabled ? "relay" : undefined,
+      });
 
       const createChatChannel = (newConnection: RTCPeerConnection) => {
         try {


### PR DESCRIPTION
Add a url parameter to force relay connections and that way hide the ip address of the client when talking with other participants.

This could be added to the UI somehow or even set by default although that has 2 problems: a) cost and b) if there is any issue with the turn infra the service will stop working

I would also leave iceCandidatePoolSize with default values, simpler and I don't see it worse than using 1 for this use case.

Feel free to reject the PR, it was only done for fun while taking a look at the code and it is not a great contribution anyway :)